### PR TITLE
Validate context window size in ChainOfAgents

### DIFF
--- a/Chain of Agent/chain_of_agent.py
+++ b/Chain of Agent/chain_of_agent.py
@@ -29,6 +29,33 @@ class ChainOfAgents:
         return final_output
     
     def split_input_into_chunks(self, input_text: str, window_size: int) -> List[str]:
+        """Split *input_text* into chunks of at most *window_size* tokens.
+
+        Parameters
+        ----------
+        input_text: str
+            The full text that needs to be processed.
+        window_size: int
+            Maximum number of tokens allowed in each chunk.  Must be
+            greater than zero.
+
+        Returns
+        -------
+        List[str]
+            A list where each element is a string containing up to
+            ``window_size`` whitespace separated tokens.
+
+        Raises
+        ------
+        ValueError
+            If ``window_size`` is less than 1.  Previously a value of 0
+            would cause ``range`` to raise ``ValueError: step must not be
+            zero`` when creating the chunks.
+        """
+
+        if window_size < 1:
+            raise ValueError("window_size must be at least 1")
+
         # Split input into smaller chunks based on the context window size
         tokens = input_text.split()  # Simplified tokenization, assume whitespace separates tokens
         chunks = [tokens[i:i + window_size] for i in range(0, len(tokens), window_size)]

--- a/Chain of Agent/test_chain_of_agent_split.py
+++ b/Chain of Agent/test_chain_of_agent_split.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import pytest
+
+# Ensure the module path includes the directory of this file
+sys.path.append(os.path.dirname(__file__))
+
+from chain_of_agent import ChainOfAgents
+
+def test_split_input_into_chunks_valid():
+    c = ChainOfAgents(long_input="", context_window_size=2, model="m", api_key="k")
+    chunks = c.split_input_into_chunks("a b c d", 2)
+    assert chunks == ["a b", "c d"]
+
+
+def test_split_input_into_chunks_invalid():
+    c = ChainOfAgents(long_input="", context_window_size=1, model="m", api_key="k")
+    with pytest.raises(ValueError):
+        c.split_input_into_chunks("some text", 0)
+


### PR DESCRIPTION
## Summary
- guard against zero or negative window sizes in `ChainOfAgents.split_input_into_chunks`
- document chunking behavior and error condition
- add tests covering valid and invalid chunk splitting

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895726aa5648330887147249062eef7

## Summary by Sourcery

Validate and document the context window size in `ChainOfAgents.split_input_into_chunks`, and add tests to cover valid and invalid chunking scenarios

Bug Fixes:
- Prevent `split_input_into_chunks` from accepting zero or negative window sizes

Enhancements:
- Add docstring to `split_input_into_chunks` detailing parameters, return value, and error conditions

Tests:
- Add tests for valid splitting and raising `ValueError` on invalid window size